### PR TITLE
Update chromium-flags.conf

### DIFF
--- a/.config/chromium-flags.conf
+++ b/.config/chromium-flags.conf
@@ -1,3 +1,3 @@
---ignore-gpu-blacklist
+--ignore-gpu-blocklist
 --enable-gpu-rasterization
 --enable-zero-copy


### PR DESCRIPTION
fixes
```
[148350:148369:1124/234950.290125:ERROR:service_utils.cc(157)] --ignore-gpu-blacklist is deprecated and will be removed in 2020Q4, use --ignore-gpu-blocklist instead.
```